### PR TITLE
Scala 3 top level main

### DIFF
--- a/src/main/g8/src/main/scala/Main.scala
+++ b/src/main/g8/src/main/scala/Main.scala
@@ -1,11 +1,6 @@
-
-object Main {
-
-  def main(args: Array[String]): Unit = {
+def main(args: Array[String]): Unit = {
     println("Hello world!")
     println(msg)
   }
 
-  def msg = "I was compiled by dotty :)"
-
-}
+def msg = "I was compiled by dotty :)"

--- a/src/main/g8/src/test/scala/Test1.scala
+++ b/src/main/g8/src/test/scala/Test1.scala
@@ -4,6 +4,6 @@ import org.junit.Assert._
 
 class Test1 {
   @Test def t1(): Unit = {
-    assertEquals("I was compiled by dotty :)", Main.msg)
+    assertEquals("I was compiled by dotty :)", msg)
   }
 }


### PR DESCRIPTION
This changes help highlighting how concise Scala 3 is, by getting rid of the singleton object holding the main function. Instead, the main function is defined top level, which isn't something possible in Scala 2.

