### PR TITLE
Changed most Dotty references to Scala 3

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,9 +1,8 @@
-## sbt project compiled with Dotty
+## sbt project compiled with Scala 3
 
 ### Usage
 
-This is a normal sbt project, you can compile code with `sbt compile` and run it
-with `sbt run`, `sbt console` will start a Dotty REPL.
+This is a normal sbt project. You can compile code with `sbt compile`, run it with `sbt run`, and `sbt console` will start a Scala 3 REPL.
 
 For more information on the sbt-dotty plugin, see the
 [dotty-example-project](https://github.com/lampepfl/dotty-example-project/blob/master/README.md).

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,12 +1,12 @@
-val dottyVersion = "3.0.0-M2"
+val scala3Version = "3.0.0-M2"
 
 lazy val root = project
   .in(file("."))
   .settings(
-    name := "dotty-simple",
+    name := "scala3-simple",
     version := "0.1.0",
 
-    scalaVersion := dottyVersion,
+    scalaVersion := scala3Version,
 
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   )

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,2 +1,2 @@
-name=Dotty Project Template
-description=A template to demonstrate a minimal Dotty application
+name=Scala 3 Project Template
+description=A template to demonstrate a minimal Scala 3 application

--- a/src/main/g8/src/main/scala/Main.scala
+++ b/src/main/g8/src/main/scala/Main.scala
@@ -1,6 +1,6 @@
 def main(args: Array[String]): Unit = {
     println("Hello world!")
     println(msg)
-  }
+}
 
-def msg = "I was compiled by dotty :)"
+def msg = "I was compiled by Scala 3. :)"

--- a/src/main/g8/src/test/scala/Test1.scala
+++ b/src/main/g8/src/test/scala/Test1.scala
@@ -4,6 +4,6 @@ import org.junit.Assert._
 
 class Test1 {
   @Test def t1(): Unit = {
-    assertEquals("I was compiled by dotty :)", msg)
+    assertEquals("I was compiled by Scala 3. :)", msg)
   }
 }


### PR DESCRIPTION
I just used this template and noticed that it still references Dotty in several places, so I updated those. I also modified the README slightly.

Also, I didn’t know how to test this code, so please consider it untested.