### PR TITLE
Use the given name for the project instead of a default one

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -3,8 +3,8 @@ val scala3Version = "3.0.2"
 lazy val root = project
   .in(file("."))
   .settings(
-    name := "scala3-simple",
-    version := "0.1.0",
+    name := "$name$",
+    version := "0.1.0-SNAPSHOT",
 
     scalaVersion := scala3Version,
 


### PR DESCRIPTION
Instead of using `scala3-simple` as a name for the project in the sbt build, it's better to use the name the user gave when creating the project from the template.