### PR TITLE
Update `junit-interface` to the newest version

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,5 +8,5 @@ lazy val root = project
 
     scalaVersion := scala3Version,
 
-    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
+    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
   )


### PR DESCRIPTION
https://github.com/scalameta/metals/pull/3619 will allow running single junit4 tests, but it needs newest junit-interface to do that