### PR TITLE
Create .gitignore in generated project

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,0 +1,29 @@
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+.ensime
+.ensime_cache/
+.sbt-scripted/
+local.sbt
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # sbt specific
 dist/*
 target/


### PR DESCRIPTION
add a standard gitignore for sbt projects in use with an IDE, I used the one from https://github.com/scalacenter/tasty-query

fixes #92 