### PR TITLE
Make build.sbt more beginner friendly

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,5 +8,5 @@ lazy val root = project
 
     scalaVersion := scala3Version,
 
-    libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
   )


### PR DESCRIPTION
With the added comma, it does not matter whether a dependency is added before or after the existing line.

This can trip up beginners, as the error message is not the best if they forget: "string literal found, but ) expected"